### PR TITLE
remove erroneous files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,9 +77,11 @@ parts:
       if [ "${ARCHITECTURE}" = "amd64" ]; then
         mv ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux64 ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux
         sed -i 's/linux64/linux/g' ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux/gitter.desktop
+        rm $SNAPCRAFT_PART_INSTALL/opt/Gitter/linux/nacl_irt_x86_64.nexe
       elif [ "${ARCHITECTURE}" = "i386" ]; then
         mv ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux32 ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux
         sed -i 's/linux32/linux/g' ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux/gitter.desktop
+        rm $SNAPCRAFT_PART_INSTALL/opt/Gitter/linux/nacl_irt_x86_32.nexe
       fi
 
       VERSION=$(echo "${DEB}" | cut -d'_' -f2)


### PR DESCRIPTION
The files listed are causing this snap to fail security review in the store. We should test this and if okay, merge it.