### PR TITLE
Migrate to GNOME 3.28

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,7 @@ apps:
     extensions: [gnome-3-28]
     command: opt/Gitter/linux/Gitter
     desktop: opt/Gitter/linux/gitter.desktop
+    autostart: gitter.desktop
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,16 +91,10 @@ apps:
       DISABLE_WAYLAND: 1
     plugs:
       - browser-support
-      - desktop
-      - desktop-legacy
-      - gsettings
       - home
-      - mount-observe
       - network
       - network-bind
       - opengl
       - pulseaudio
       - screen-inhibit-control
       - unity7
-      - wayland
-      - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,6 +72,14 @@ parts:
       - libxss1
     prime:
       - -opt/Gitter/linux/nacl_irt_*.nexe
+  cleanup:
+    after: [gitter-desktop]
+    plugin: nil
+    build-snaps: [ gnome-3-28-1804 ]
+    override-prime: |
+        set -eux
+        cd /snap/gnome-3-28-1804/current
+        find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
     
 apps:
   gitter-desktop:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,45 +13,13 @@ architectures:
   - build-on: amd64
   - build-on: i386
 
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/data-dir/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/data-dir/icons
-    default-provider: gtk-common-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/data-dir/sounds
-    default-provider: gtk-common-themes
-
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
     plugin: nil
     source: https://gitlab.com/gitlab-org/gitter/desktop.git
-  desktop-gnome-platform:
-    build-packages:
-    - build-essential
-    - libgtk-3-dev
-    make-parameters:
-    - FLAVOR=gtk3
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
 
   libappindicator:
     plugin: nil
-    after:
-      - desktop-gnome-platform
     stage-packages:
       - libappindicator3-1
     prime:
@@ -93,15 +61,12 @@ parts:
       VERSION=$(echo "${DEB}" | cut -d'_' -f2)
       snapcraftctl set-version "$VERSION"
     after:
-      - desktop-gnome-platform
       - libappindicator
     build-packages:
       - dpkg
       - sed
       - wget
     stage-packages:
-      - libasound2
-      - libgconf2-4
       - libnspr4
       - libnss3
       - libxss1
@@ -110,7 +75,8 @@ parts:
     
 apps:
   gitter-desktop:
-    command: bin/desktop-launch $SNAP/opt/Gitter/linux/Gitter
+    extensions: [gnome-3-28]
+    command: opt/Gitter/linux/Gitter
     desktop: opt/Gitter/linux/gitter.desktop
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to


### PR DESCRIPTION
This pull request migrates to the GNOME 3.28 platform snap, adds autostart and reduces the size of the snap by ~20MB.