### PR TITLE
Fix for gitter 5.0.0+

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,11 +51,9 @@ parts:
       if [ "${ARCHITECTURE}" = "amd64" ]; then
         mv ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux64 ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux
         sed -i 's/linux64/linux/g' ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux/gitter.desktop
-        rm $SNAPCRAFT_PART_INSTALL/opt/Gitter/linux/nacl_irt_x86_64.nexe
       elif [ "${ARCHITECTURE}" = "i386" ]; then
         mv ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux32 ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux
         sed -i 's/linux32/linux/g' ${SNAPCRAFT_PART_INSTALL}/opt/Gitter/linux/gitter.desktop
-        rm $SNAPCRAFT_PART_INSTALL/opt/Gitter/linux/nacl_irt_x86_32.nexe
       fi
 
       VERSION=$(echo "${DEB}" | cut -d'_' -f2)
@@ -67,11 +65,10 @@ parts:
       - sed
       - wget
     stage-packages:
+      - libatomic1
       - libnspr4
       - libnss3
       - libxss1
-    prime:
-      - -opt/Gitter/linux/nacl_irt_*.nexe
   cleanup:
     after: [gitter-desktop]
     plugin: nil
@@ -98,6 +95,7 @@ apps:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:
+      - audio-playback
       - browser-support
       - home
       - network


### PR DESCRIPTION
* Add `audio-playback` plug now that is standardised
* Add required `libatomic1` shared library
* Don't delete nexe files (reduces noise in terminal output)

Fixes #15 

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>